### PR TITLE
fix: broken doc links in package.json files

### DIFF
--- a/packages/root-cause-core/package.json
+++ b/packages/root-cause-core/package.json
@@ -34,7 +34,7 @@
   "bugs": {
     "url": "https://github.com/testimio/root-cause/issues"
   },
-  "homepage": "https://help.testim.io/docs/testim-root-cause-overview",
+  "homepage": "https://help.testim.io/docs/root-cause",
   "dependencies": {
     "@testim/chrome-har": "^0.0.0-6a7c1f3",
     "abort-controller": "^3.0.0",

--- a/packages/root-cause-jest/package.json
+++ b/packages/root-cause-jest/package.json
@@ -33,7 +33,7 @@
   "bugs": {
     "url": "https://github.com/testimio/root-cause/issues"
   },
-  "homepage": "https://help.testim.io/docs/testim-root-cause-overview",
+  "homepage": "https://help.testim.io/docs/root-cause",
   "peerDependencies": {
     "@jest/reporters": "^26.4.1 || ^25.5.1"
   },

--- a/packages/root-cause-mocha/package.json
+++ b/packages/root-cause-mocha/package.json
@@ -29,7 +29,7 @@
   "bugs": {
     "url": "https://github.com/testimio/root-cause/issues"
   },
-  "homepage": "https://help.testim.io/docs/testim-root-cause-overview",
+  "homepage": "https://help.testim.io/docs/root-cause",
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/fs-extra": "^9.0.2",

--- a/packages/root-cause-types/package.json
+++ b/packages/root-cause-types/package.json
@@ -17,7 +17,7 @@
   "bugs": {
     "url": "https://github.com/testimio/root-cause/issues"
   },
-  "homepage": "https://help.testim.io/docs/testim-root-cause-overview",
+  "homepage": "https://help.testim.io/docs/root-cause",
   "devDependencies": {
     "typescript": "^3.9.7"
   },

--- a/packages/root-cause/package.json
+++ b/packages/root-cause/package.json
@@ -30,7 +30,7 @@
   "bugs": {
     "url": "https://github.com/testimio/root-cause/issues"
   },
-  "homepage": "https://help.testim.io/docs/testim-root-cause-overview",
+  "homepage": "https://help.testim.io/docs/root-cause",
   "dependencies": {
     "@testim/root-cause-core": "0.1.30",
     "@testim/root-cause-jest": "0.1.30"


### PR DESCRIPTION
homepage entries in `package.json` files are broken and link to a 404 page.